### PR TITLE
Reorder comments within root

### DIFF
--- a/mcfunction.tmLanguage
+++ b/mcfunction.tmLanguage
@@ -883,11 +883,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#names</string>
+					<string>#comments</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#comments</string>
+					<string>#names</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/mcfunction.tmLanguage.json
+++ b/mcfunction.tmLanguage.json
@@ -18,10 +18,10 @@
           "include": "#literals"
         },
         {
-          "include": "#names"
+          "include": "#comments"
         },
         {
-          "include": "#comments"
+          "include": "#names"
         },
         {
           "include": "#subcommands"

--- a/mcfunction.tmLanguage.yaml
+++ b/mcfunction.tmLanguage.yaml
@@ -14,8 +14,8 @@ repository:
   root:
     patterns:
     - include: '#literals'
-    - include: '#names'
     - include: '#comments'
+    - include: '#names'
     - include: '#subcommands'
     - include: '#property'
     - include: '#operators'


### PR DESCRIPTION
Fixes #2. Bumped comment precedence so they won't get mistaken for other bits of syntax. As I said in the issue thread, this should be tested before merging.